### PR TITLE
Allow translate use preloaded schema

### DIFF
--- a/lib/iuliia.ex
+++ b/lib/iuliia.ex
@@ -19,5 +19,10 @@ defmodule Iuliia do
     Iuliia.Engine.translate(string, schema_name)
   end
 
+  @spec translate(String.t(), map()) :: String.t()
+  def translate(string, schema) when is_map(schema) do
+    Iuliia.Engine.translate(string, schema)
+  end
+
   def translate(non_string, _), do: non_string
 end

--- a/lib/iuliia/engine.ex
+++ b/lib/iuliia/engine.ex
@@ -12,9 +12,14 @@ defmodule Iuliia.Engine do
       "Yuliya, syesh' eshche etikh myagkikh frantsuzskikh bulok iz Yoshkar-Oly, da vypey altayskogo chayu"
   """
   @spec translate(String.t(), String.t()) :: String.t()
-  def translate(string, schema_name) do
+  def translate(string, schema_name) when is_binary(schema_name) do
     schema = Iuliia.Schema.lookup(schema_name)
 
+    translate(string, schema)
+  end
+
+  @spec translate(String.t(), map()) :: String.t()
+  def translate(string, schema) when is_map(schema) do
     translated_chunks =
       for word <- String.split(string, ~r/\b/u, trim: true), do: translit_chunk(schema, word)
 

--- a/test/iuliia_test.exs
+++ b/test/iuliia_test.exs
@@ -15,6 +15,20 @@ defmodule IuliiaTest do
         end
       end
     end
+
+    test "translates samples for preloaded schema" do
+      for schema_path <- Path.wildcard("lib/schemas/*.json") do
+        schema = schema_path |> File.read!() |> Jason.decode!()
+
+        schema_name = schema["name"]
+        IO.puts(schema_name)
+
+        for sample <- schema["samples"] do
+          schema = Iuliia.Schema.lookup(schema_name)
+          assert Iuliia.Engine.translate(Enum.at(sample, 0), schema) == Enum.at(sample, 1)
+        end
+      end
+    end
   end
 
   describe ".lookup" do


### PR DESCRIPTION
Sometimes it is necessary to use the same transliteration scheme many thousand times.
I added the ability to preload the schema and allowed it to be passed as the 2nd argument to the transliteration function.